### PR TITLE
feat: add handwriting sheet generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,9 @@ scikit-learn
 
 # Image processing
 opencv-python
-Pillow
+pillow
+reportlab
+fonttools
 
 # API
 fastapi

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -2,3 +2,34 @@
 # - config.py (configuration loading)
 # - visualization.py (plotting helpers)
 # - io.py (file I/O helpers)
+from .handwriting_sheet_io import create_pdf, save_temp_font
+from .handwriting_sheet_config import (
+    DUONG_DAN, ENGLISH_TEXT, FONT_NAME, VIETNAMESE_TEXT, EN_filename, 
+    VI_filename, chia_doc, chia_ngang, le_duoi, le_phai, le_trai, 
+    le_tren, size
+)
+from .handwriting_sheet_visualization import (
+    create_english_sheet, create_vietnamese_sheet, set_font, tim_thu_muc
+)
+
+__all__ = [
+    "create_pdf",
+    "save_temp_font",
+    "DUONG_DAN",
+    "ENGLISH_TEXT",
+    "FONT_NAME",
+    "VIETNAMESE_TEXT",
+    "EN_filename",
+    "VI_filename",
+    "chia_doc",
+    "chia_ngang",
+    "le_duoi",
+    "le_phai",
+    "le_trai",
+    "le_tren",
+    "size",
+    "create_english_sheet",
+    "create_vietnamese_sheet",
+    "set_font",
+    "tim_thu_muc"
+]

--- a/src/utils/handwriting_sheet_config.py
+++ b/src/utils/handwriting_sheet_config.py
@@ -1,0 +1,61 @@
+# TEXT
+ENGLISH_TEXT = """
+The quick brown fox jumps over the lazy dog
+THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG
+"""
+VIETNAMESE_TEXT = """
+
+a à á ả ã ạ
+ă ằ ắ ẳ ẵ ặ
+â ầ ấ ẩ ẫ ậ
+e è é ẻ ẽ ẹ
+ê ề ế ể ễ ệ
+i ì í ỉ ĩ ị
+o ò ó ỏ õ ọ
+ô ồ ố ổ ỗ ộ
+ơ ờ ớ ở ỡ ợ
+u ù ú ủ ũ ụ
+ư ừ ứ ử ữ ự
+y ỳ ý ỷ ỹ ỵ
+
+A À Á Ả Ã Ạ
+Ă Ằ Ắ Ẳ Ẵ Ặ
+Â Ầ Ấ Ẩ Ẫ Ậ
+E È É Ẻ Ẽ Ẹ
+Ê Ề Ế Ể Ễ Ệ
+I Ì Í Ỉ Ĩ Ị
+O Ò Ó Ỏ Õ Ọ
+Ô Ồ Ố Ổ Ỗ Ộ
+Ơ Ờ Ớ Ở Ỡ Ợ
+U Ù Ú Ủ Ũ Ụ
+Ư Ừ Ứ Ử Ữ Ự
+Y Ỳ Ý Ỷ Ỹ Ỵ
+
+b c d đ g h k l m n p q r s t v x
+B C D Đ G H K L M N P Q R S T V X
+"""
+
+# ĐƯỜNG DẪN CHỨA PDF
+DUONG_DAN = "data/user_samples"
+# KÍCH THƯỚC CHỮ
+size = 15
+
+# FONT NAME
+FONT_NAME = "handwriting_sheet"
+# FILENAME
+EN_filename = "english_handwriting_sheet.pdf"
+VI_filename = "Vietnamese_handwriting_sheet.pdf"
+
+# A4 SIZE
+height = 841
+widght = 594
+
+# căn lề
+le_trai = 40
+le_phai = 555
+le_tren = 802
+le_duoi = 40
+
+# chia cấu trúc
+chia_ngang = 421
+chia_doc = 297

--- a/src/utils/handwriting_sheet_io.py
+++ b/src/utils/handwriting_sheet_io.py
@@ -1,0 +1,18 @@
+import os
+import tempfile
+
+def save_temp_font(uploaded_file):
+    temp_font = tempfile.NamedTemporaryFile(delete=False, suffix=".ttf")
+    temp_font.write(uploaded_file.read())
+    temp_font.close()
+    return temp_font.name
+
+def create_pdf(pdf, temp_font_path=None):
+    try:
+        pdf.save()
+    except Exception as e:
+        raise RuntimeError(f"Hệ thống không thể lưu PDF. Chi tiết: {e}")
+        
+    finally:
+        if temp_font_path and os.path.exists(temp_font_path):
+            os.remove(temp_font_path)

--- a/src/utils/handwriting_sheet_visualization.py
+++ b/src/utils/handwriting_sheet_visualization.py
@@ -1,0 +1,153 @@
+from .handwriting_sheet_config import (
+    ENGLISH_TEXT, FONT_NAME, VIETNAMESE_TEXT, EN_filename, 
+    VI_filename, chia_doc, chia_ngang, le_duoi, le_phai, le_trai, 
+    le_tren, size
+)
+from pathlib import Path
+import os
+from reportlab.pdfgen import canvas
+from reportlab.lib.pagesizes import A4
+from reportlab.pdfbase.ttfonts import TTFont
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.pdfmetrics import stringWidth
+from fontTools.ttLib import TTFont as FT_Font
+
+
+def tim_thu_muc(duong_dan):
+    thu_muc_bat_dau = Path(__file__).resolve().parent
+    cac_cap_thu_muc = [thu_muc_bat_dau] + list(thu_muc_bat_dau.parents)
+
+    for thu_muc_cha in cac_cap_thu_muc:
+        duong_dan_kiem_tra = thu_muc_cha / duong_dan
+
+        if duong_dan_kiem_tra.is_dir():
+            return str(duong_dan_kiem_tra)
+
+    raise FileNotFoundError(
+        f"Đã lùi hết cỡ nhưng không tìm thấy tổ hợp thư mục: '{duong_dan}'"
+    )
+
+
+def set_font(pdf, temp_font_path, font_size):
+    pdfmetrics.registerFont(TTFont(FONT_NAME, temp_font_path))
+    pdf.setFont(FONT_NAME, font_size)
+
+
+def create_english_sheet(temp_font_path, duong_dan):
+    thu_muc = tim_thu_muc(duong_dan)
+    duong_dan_luu_tep = os.path.join(thu_muc, EN_filename)
+    pdf = canvas.Canvas(duong_dan_luu_tep, pagesize=A4)
+
+    set_font(pdf, temp_font_path, size)
+
+    y = le_tren
+    phan_tren = True
+    for EN_text in ENGLISH_TEXT.strip().splitlines():
+        mau = True
+        while True:
+            if stringWidth(EN_text, FONT_NAME, size) < le_phai - 40:
+                x = le_trai + (
+                    (le_phai - le_trai - stringWidth(EN_text, FONT_NAME, size)) / 2
+                )
+            else:
+                x = le_trai
+
+            if mau:
+                pdf.setFillColorRGB(0, 0, 0)
+                mau = False
+            else:
+                pdf.setFillColorRGB(0.6, 0.6, 0.6)
+
+            
+
+
+            pdf.drawString(x, y, EN_text)
+
+            offset = size*0.1
+            pdf.setStrokeColorRGB(0.9, 0.9, 0.9)
+            pdf.line( 10 , y - offset, 835 , y - offset)
+
+
+
+            y -= size + 5
+
+            if y < chia_ngang and phan_tren:
+                phan_tren = False
+                break
+            if y < 20:
+                break
+
+    return pdf
+
+
+def create_vietnamese_sheet(temp_font_path, duong_dan):
+    thu_muc = tim_thu_muc(duong_dan)
+    duong_dan_luu_tep = os.path.join(thu_muc, VI_filename)
+
+    pdf = canvas.Canvas(duong_dan_luu_tep, pagesize=A4)
+
+    set_font(pdf, temp_font_path, size)
+
+    phan_trai = True
+    x_pos = le_trai
+    y_pos = le_tren
+    for vi_char in VIETNAMESE_TEXT.split():
+        chu_mau = True
+        x = x_pos
+        gioi_han_phai = chia_doc if phan_trai else le_phai
+
+        while True:
+            
+            if chu_mau:
+                pdf.setFillColorRGB(0, 0, 0)
+                chu_mau = False
+            else:
+                pdf.setFillColorRGB(0.7, 0.7, 0.7)
+
+            pdf.drawString(x, y_pos, vi_char)
+            x += size + 5
+
+            
+            
+
+            if x > (gioi_han_phai - 10):
+                break
+
+        offset = size*0.1
+        pdf.setStrokeColorRGB(0.9, 0.9, 0.9)
+        pdf.line( x_pos-5 , y_pos - offset, x - 5  , y_pos - offset)
+
+        pdf.setStrokeColorRGB(0.2, 0.2, 0.2)
+        pdf.line(chia_doc, 830 , chia_doc, 10)
+
+        y_pos -= size + 15
+
+        if y_pos < le_duoi:
+            if phan_trai:
+                x_pos = chia_doc + 10
+                y_pos = le_tren
+                phan_trai = False
+            else:
+
+                phan_trai = True
+                x_pos = le_trai
+                y_pos = le_tren
+                pdf.showPage()
+                set_font(pdf, temp_font_path, size)
+                
+
+    return pdf
+
+
+def is_vietnamese_font(temp_font_path):
+    try:
+        bang_ma = FT_Font(temp_font_path).getBestCmap()
+        cac_chu_can_in = set(char for char in VIETNAMESE_TEXT if char.strip())
+
+        for char in cac_chu_can_in:
+            if ord(char) not in bang_ma:
+                return False
+        return True
+
+    except Exception as e:
+        raise RuntimeError(f"Lỗi hệ thống khi đọc dữ liệu font: {e}")

--- a/src/utils/test_utils.py
+++ b/src/utils/test_utils.py
@@ -1,0 +1,60 @@
+import tkinter as tk
+from tkinter import filedialog
+import traceback
+from .handwriting_sheet_config import (
+    DUONG_DAN 
+    )
+
+from .handwriting_sheet_io import save_temp_font, create_pdf
+from .handwriting_sheet_visualization import create_english_sheet, create_vietnamese_sheet, is_vietnamese_font
+
+
+def main():
+    print("Khởi động chương trình tạo PDF...")
+
+    #  Khởi tạo giao diện chọn FONT
+    root = tk.Tk()
+    root.withdraw()
+
+    # 1. INPUT :
+    file_path = filedialog.askopenfilename(
+        title="Hãy chọn một file Font chữ ",
+        filetypes=[("Font TrueType", "*.ttf"), ("Tất cả các file", "*.*")],
+    )
+
+    if not file_path:
+        print(" Bạn chưa chọn file font. Đang thoát chương trình...")
+        return
+
+    print(f" Đã chọn file font: {file_path}")
+
+    try:
+        with open(file_path, "rb") as uploaded_file:
+            duong_dan_font_tam = save_temp_font(uploaded_file)
+
+        if not duong_dan_font_tam:
+            print("Không thể tạo file font tạm thời.")
+            return
+
+        # Kiểm tra FONT có hỗ trợ Tiếng Việt hay không
+        is_vietnamese = is_vietnamese_font(duong_dan_font_tam)
+
+        if is_vietnamese:
+            print("Font có hỗ trợ Tiếng Việt")
+            my_pdf = create_vietnamese_sheet(duong_dan_font_tam, DUONG_DAN)
+        else:
+            print("🇬🇧 Font này chỉ gõ được Tiếng Anh. Đang tạo vở Tiếng Anh...")
+            my_pdf = create_english_sheet(duong_dan_font_tam, DUONG_DAN)
+
+        # 2. OUTPUT :
+        create_pdf(my_pdf, duong_dan_font_tam)
+        print("QUÁ TRÌNH HOÀN TẤT!")
+
+    except Exception as e:
+        print(f" Có lỗi bất ngờ xảy ra: {e}")
+        traceback.print_exc()
+
+
+#
+if __name__ == "__main__":
+    main()

--- a/tests/test_sheet_making.py
+++ b/tests/test_sheet_making.py
@@ -1,0 +1,60 @@
+import tkinter as tk
+from tkinter import filedialog
+import traceback
+from src.utils.handwriting_sheet_config import (
+    DUONG_DAN 
+    )
+
+from src.utils.handwriting_sheet_io import save_temp_font, create_pdf
+from src.utils.handwriting_sheet_visualization import create_english_sheet, create_vietnamese_sheet, is_vietnamese_font
+
+
+def main():
+    print("Khởi động chương trình tạo PDF...")
+
+    #  Khởi tạo giao diện chọn FONT
+    root = tk.Tk()
+    root.withdraw()
+
+    # 1. INPUT :
+    file_path = filedialog.askopenfilename(
+        title="Hãy chọn một file Font chữ ",
+        filetypes=[("Font TrueType", "*.ttf"), ("Tất cả các file", "*.*")],
+    )
+
+    if not file_path:
+        print(" Bạn chưa chọn file font. Đang thoát chương trình...")
+        return
+
+    print(f" Đã chọn file font: {file_path}")
+
+    try:
+        with open(file_path, "rb") as uploaded_file:
+            duong_dan_font_tam = save_temp_font(uploaded_file)
+
+        if not duong_dan_font_tam:
+            print("Không thể tạo file font tạm thời.")
+            return
+
+        # Kiểm tra FONT có hỗ trợ Tiếng Việt hay không
+        is_vietnamese = is_vietnamese_font(duong_dan_font_tam)
+
+        if is_vietnamese:
+            print("Font có hỗ trợ Tiếng Việt")
+            my_pdf = create_vietnamese_sheet(duong_dan_font_tam, DUONG_DAN)
+        else:
+            print("🇬🇧 Font này chỉ gõ được Tiếng Anh. Đang tạo vở Tiếng Anh...")
+            my_pdf = create_english_sheet(duong_dan_font_tam, DUONG_DAN)
+
+        # 2. OUTPUT :
+        create_pdf(my_pdf, duong_dan_font_tam)
+        print("QUÁ TRÌNH HOÀN TẤT!")
+
+    except Exception as e:
+        print(f" Có lỗi bất ngờ xảy ra: {e}")
+        traceback.print_exc()
+
+
+#
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
1. Thêm vào các thư viện ( chỉnh sửa trên requirements.txt )
   - reportlab : tạo tệp pdf, in nội dung lên tệp pdf, lưu tệp pdf
   - fonttools : định dạng file font thành font chữ ; kiểm tra xem trong file font chứa những gì ( hỗ trợ hàm is_vietnames_font  )
  2. Thêm vào các tệp : 
   2.1. __init__ : khai báo các module dễ dàng hơn
   2.2. handwriting_sheet_config : chứa địa chỉ lưu file  và tên handwriting sheet ; thông số điều chỉnh  và nội dung khi in lên pdf
   2.3. handwriting_sheet_io : 
         - hàm save_temp_font : là input , là hàm lưu file font chữ mà người dùng nhập vào
         - hàm create_pdf : là output, là hàm xuất file handwriting sheet pdf vào thư mục đường dẫn
   2.4. handwriting_sheet_visualization : 
        - hàm tim_thu_muc : tìm chính xác thư mục đường dẫn để lưu file
        - hàm is_vietnamese_font : kiểm tra xem font có hỗ trợ tiếng việt hay không
        - hàm create_english_sheet : nếu font không hỗ trợ tiếng việt, hàm này sẽ thực hiện tạo sheet với các chữ là bảng chữ nằm trong bảng chữ cái tiếng anh
        - hàm create_vietnamese_sheet : nếu font có hỗ trợ tiếng việt, hàm này sẽ thực hiện tạo sheet với các chữ nằm trong bẳng chữ cái tiếng việt
     2.5. test_utils : dùng để kiểm tra các package trong thư mục src.utils có hoạt động như thế nào

